### PR TITLE
ctypes fix to work with: python-uinput-0.6.2 - libsuinput-0.6.1

### DIFF
--- a/tuiototouch.py
+++ b/tuiototouch.py
@@ -62,7 +62,7 @@ class Device(object):
     def emit(self, event, value, syn=True):
         evtype, evcode = event
         print "type :%d code : %d value : %d" % (evtype, evcode, value)
-        self.device.emit(event, value, syn)
+        self.device.emit(event, int(value), syn)
 
 class DeviceWME(Device):
 


### PR DESCRIPTION
My first commit ever ;), hope it's helpful...New with github so sorry if im not doing this the right way... i really appreciate all the work you' ve done... would you be interested in updating the file? 

Updated: Working tuiototouch.py for Ubuntu "Oneiric" 11.10

Works with CCV 1.4 thru installed python-uinput.6.2(libsuinput.0.6.1) and installed pyTUIO.0.1 (patched in line 39: self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1) instead of SO_REUSEPORT)

This is to avoid ctypes argument error when parsing "value" (argument 4).
libsuinput expects int-type values and python without the "int(value)" sends float-type values.
